### PR TITLE
46-New-Model-we-use-NECGlobalEntry-instead-we-should-implement-our-own

### DIFF
--- a/src/NewCompletion/CompletionEntry.class.st
+++ b/src/NewCompletion/CompletionEntry.class.st
@@ -1,0 +1,32 @@
+"
+One main Entry class instead of NECEntry functionality
+"
+Class {
+	#name : #CompletionEntry,
+	#superclass : #Object,
+	#instVars : [
+		'contents',
+		'type'
+	],
+	#category : #'NewCompletion-Model'
+}
+
+{ #category : #accessing }
+CompletionEntry class >> contents: aString [ 
+	^ self new setContents: aString
+]
+
+{ #category : #accessing }
+CompletionEntry >> contents [
+	^contents
+]
+
+{ #category : #initialization }
+CompletionEntry >> setContents: aString [ 
+	contents := aString.
+]
+
+{ #category : #initialization }
+CompletionEntry >> type [
+	^ type
+]

--- a/src/NewCompletion/CompletionModel.class.st
+++ b/src/NewCompletion/CompletionModel.class.st
@@ -79,7 +79,7 @@ CompletionModel >> initEntries [
 	producer := MatchedNodeProducer new.
 	producer completionContext: clazz.
 	temp := (producer completionListForNode: node) asOrderedCollection. 
-	^ temp collect: [ :each | NECGlobalEntry contents: each ]
+	^ temp collect: [ :each | CompletionEntry contents: each ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
testing a single entry